### PR TITLE
Added Favourites Autostart

### DIFF
--- a/PartymodeAutostart.py
+++ b/PartymodeAutostart.py
@@ -47,6 +47,8 @@ class Main:
         self.avoidOnPauseStartOnScreensaverPartyMode    = __addon__.getSetting('avoid-on-pause-start-on-screensaver-partymode') == 'true'
         self.startupPlaylist                            = __addon__.getSetting('startup-playlist') == 'true'
         self.startupPlaylistPath                        = xbmc.getInfoLabel( "Skin.String(Startup.Playlist.Path)" )
+        self.startupFavourites                          = __addon__.getSetting('startup-favourites') == 'true'
+        self.startupFavouritesPath                      = xbmc.getInfoLabel('Skin.String(Startup.Favourites.Path)')
 
         self.visualisationPartymode                     = __addon__.getSetting('visualisation-partymode') == 'true'
         self.delayVisualisationPartyMode                = int(__addon__.getSetting('delay-visualisation-partymode'))
@@ -63,6 +65,13 @@ class Main:
             log('Start Playlist: ' + self.startupPlaylistPath)
 
             xbmc.executebuiltin("XBMC.PlayMedia(" + self.startupPlaylistPath + ")")
+
+        elif self.startupFavourites:
+
+            log('Start Favourites: ' + self.startupFavouritesPath)
+
+            xbmc.executebuiltin(self.startupFavouritesPath)
+
         else:
 
             log('Start PartyMode')

--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Manual install service addon: [Download ZIP](https://github.com/elbowz/partymode
 
 ### Thanks
 * To [service.scrobbler.librefm](http://github.com/XBMC-Addons/service.scrobbler.librefm) and [XBMC-Partymode-Autostart](http://github.com/mindrunner/XBMC-Partymode-Autostart) for inspiration
+* To [script.favourites](https://github.com/ronie/script.favourites)

--- a/addon.xml
+++ b/addon.xml
@@ -5,6 +5,7 @@
        provider-name="muttley">
     <requires>
         <import addon="xbmc.python" version="2.12.0"/>
+        <import addon="script.favourites" version="6.0.3"/>
     </requires>
     <extension point="xbmc.service" library="PartymodeAutostart.py" start="login"/>
     <extension point="xbmc.python.script" library="main.py">

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -47,6 +47,10 @@ msgctxt "#30014"
 msgid "Volume Adjust"
 msgstr ""
 
+msgctxt "#30015"
+msgid "Run Favourites"
+msgstr ""
+
 # setting items
 msgctxt "#30040"
 msgid "Enable"
@@ -70,6 +74,10 @@ msgstr ""
 
 msgctxt "#30045"
 msgid "Volume (%)"
+msgstr ""
+
+msgctxt "#30046"
+msgid "Select from Favourites"
 msgstr ""
 
 # ADDON STRINGS

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -11,6 +11,10 @@
 		<setting id="startup-playlist" type="bool" label="30040" default="false"/>
 		<setting type="action" label="30043" action="Skin.SetFile(Startup.Playlist.Path,,special://musicplaylists/)"/>
 		<setting id="startup-playlist-path" type="text" label="$INFO[Skin.String(Startup.Playlist.Path)]" value="$INFO[Skin.String(Startup.Playlist.Path)]" enable="false"/>
+		<setting label="30015" type="lsep"/>
+		<setting id="startup-favourites" type="bool" label="30040" default="false"/>
+		<setting type="action" label="30046" action="RunScript(script.favourites,property=Startup.Favourites)"/>
+		<setting id="startup-favourites-path" type="text" label="$INFO[Skin.String(Startup.Favourites.Label)]" value="$INFO[Skin.String(Startup.Favourites.Path)]" enable="false"/>
 	</category>
 	<category label="30001">
 		<setting label="30012" type="lsep"/>


### PR DESCRIPTION
Just added the possibility to select Favourites for Autostart.

By using script.favourites the local file userdata/favourites.xml is parsed and "self.startupFavouritesPath" is set. So "ActivateWindow" is used for a local/network folder or maybe a search from plugin.video.youtube, and "PlayMedia" is used for a live stream like plugin.video.twitch

Maybe somebody else finds this useful
