### PR TITLE
Add explicit action status to countdown window

### DIFF
--- a/PartymodeAutostart.py
+++ b/PartymodeAutostart.py
@@ -107,7 +107,13 @@ class Main:
 
     def _viewCountdown(self):
         conutdownDlg = xbmcgui.DialogProgress()
-        conutdownDlg.create( __language__(30101), __language__(30102) % self.delayStartupPartyMode)
+        if self.startupPlaylist:
+            msg = 30103
+        elif self.startupFavourites:
+            msg = 30104
+        else:
+            msg = 30102
+        conutdownDlg.create( __language__(30101), __language__(msg) % self.delayStartupPartyMode)
 
         finished = True
         countdownGap = 100

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -91,5 +91,13 @@ msgid "Countdown"
 msgstr ""
 
 msgctxt "#30102"
-msgid "PartyMode start in %s seconds:"
+msgid "PartyMode auto-start in %s seconds:"
+msgstr ""
+
+msgctxt "#30103"
+msgid "Playlist auto-start in %s seconds:"
+msgstr ""
+
+msgctxt "#30104"
+msgid "Favourite auto-start in %s seconds:"
 msgstr ""


### PR DESCRIPTION
This modification adds a description of the behavior to the countdown window. Instead of always saying "PartyMode start in _x_ seconds," the countdown window will reflect the user's settings and say one of the following:

- PartyMode auto-start in _x_ seconds:
- Playlist auto-start in _x_ seconds:
- Favourite auto-start in _x_ seconds: