### PR TITLE
Play in party mode option for playlists

### DIFF
--- a/PartymodeAutostart.py
+++ b/PartymodeAutostart.py
@@ -46,6 +46,7 @@ class Main:
         self.startOnScreensaverPartyMode                = __addon__.getSetting('start-on-screensaver-partymode') == 'true'
         self.avoidOnPauseStartOnScreensaverPartyMode    = __addon__.getSetting('avoid-on-pause-start-on-screensaver-partymode') == 'true'
         self.startupPlaylist                            = __addon__.getSetting('startup-playlist') == 'true'
+        self.startupPlaylistPartymode                   = __addon__.getSetting('startup-playlist-partymode') == 'true'
         self.startupPlaylistPath                        = xbmc.getInfoLabel( "Skin.String(Startup.Playlist.Path)" )
         self.startupFavourites                          = __addon__.getSetting('startup-favourites') == 'true'
         self.startupFavouritesPath                      = xbmc.getInfoLabel('Skin.String(Startup.Favourites.Path)')
@@ -64,7 +65,10 @@ class Main:
 
             log('Start Playlist: ' + self.startupPlaylistPath)
 
-            xbmc.executebuiltin("XBMC.PlayMedia(" + self.startupPlaylistPath + ")")
+            if self.startupPlaylistPartymode:
+                xbmc.executebuiltin("XBMC.PlayerControl(PartyMode(" + self.startupPlaylistPath + ")")
+            else:
+                xbmc.executebuiltin("XBMC.PlayMedia(" + self.startupPlaylistPath + ")")
 
         elif self.startupFavourites:
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -80,7 +80,7 @@ msgctxt "#30046"
 msgid "Select from Favourites"
 msgstr ""
 
-msgctxt "#30047"
+msgctxt "#30054"
 msgid "Play in party mode"
 msgstr ""
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -80,6 +80,10 @@ msgctxt "#30046"
 msgid "Select from Favourites"
 msgstr ""
 
+msgctxt "#30047"
+msgid "Play in party mode"
+msgstr ""
+
 # ADDON STRINGS
 
 msgctxt "#30100"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,7 +9,7 @@
 		<setting id="avoid-on-pause-start-on-screensaver-partymode" type="bool" label="30042" subsetting="true" default="true" enable="eq(-1,true)"/>
 		<setting label="30013" type="lsep"/>
 		<setting id="startup-playlist" type="bool" label="30040" default="false"/>
-		<setting id="startup-playlist-partymode" type="bool" label="30047" default="false"/>
+		<setting id="startup-playlist-partymode" type="bool" label="30054" default="false"/>
 		<setting type="action" label="30043" action="Skin.SetFile(Startup.Playlist.Path,,special://musicplaylists/)"/>
 		<setting id="startup-playlist-path" type="text" label="$INFO[Skin.String(Startup.Playlist.Path)]" value="$INFO[Skin.String(Startup.Playlist.Path)]" enable="false"/>
 		<setting label="30015" type="lsep"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,6 +9,7 @@
 		<setting id="avoid-on-pause-start-on-screensaver-partymode" type="bool" label="30042" subsetting="true" default="true" enable="eq(-1,true)"/>
 		<setting label="30013" type="lsep"/>
 		<setting id="startup-playlist" type="bool" label="30040" default="false"/>
+		<setting id="startup-playlist-partymode" type="bool" label="30047" default="false"/>
 		<setting type="action" label="30043" action="Skin.SetFile(Startup.Playlist.Path,,special://musicplaylists/)"/>
 		<setting id="startup-playlist-path" type="text" label="$INFO[Skin.String(Startup.Playlist.Path)]" value="$INFO[Skin.String(Startup.Playlist.Path)]" enable="false"/>
 		<setting label="30015" type="lsep"/>


### PR DESCRIPTION
Suggested by forum user km99:
https://forum.kodi.tv/showthread.php?tid=203290&pid=2019538#pid2019538

I chose the default text and capitalization for this setting ("Play in party mode") to match the UI from Kodi, when you open the context menu for a playlist.