### PR TITLE
Playback control options (random, repeat)

### DIFF
--- a/PartymodeAutostart.py
+++ b/PartymodeAutostart.py
@@ -56,6 +56,9 @@ class Main:
         self.volumePartyMode                            = __addon__.getSetting('volume-partymode') == 'true'
         self.volumeLevelPartyMode                       = int(__addon__.getSetting('volume-level-partymode'))
 
+        self.playbackRandom                             = int(__addon__.getSetting('playback-random'))
+        self.playbackRepeat                             = int(__addon__.getSetting('playback-repeat'))
+
     def runPartyMode(self):
         if self.volumePartyMode:
             executeJSONRPC('{{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": {{ "volume": {0}}}, "id": 1}}'.format(self.volumeLevelPartyMode))
@@ -77,6 +80,23 @@ class Main:
             log('Start PartyMode')
 
             xbmc.executebuiltin("XBMC.PlayerControl(PartyMode)")
+
+        if self.playbackRandom == 1:
+            log('Setting Random to Off')
+            xbmc.executebuiltin("XBMC.PlayerControl(RandomOff)")
+        elif self.playbackRandom == 2:
+            log('Setting Random to On')
+            xbmc.executebuiltin("XBMC.PlayerControl(RandomOn)")
+
+        if self.playbackRepeat == 1:
+            log('Setting Repeat to Off')
+            xbmc.executebuiltin("XBMC.PlayerControl(RepeatOff)")
+        elif self.playbackRepeat == 2:
+            log('Setting Repeat to One')
+            xbmc.executebuiltin("XBMC.PlayerControl(RepeatOne)")
+        elif self.playbackRepeat == 3:
+            log('Setting Repeat to All')
+            xbmc.executebuiltin("XBMC.PlayerControl(RepeatAll)")
 
         self.activateVisualisation()
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -51,6 +51,10 @@ msgctxt "#30015"
 msgid "Run Favourites"
 msgstr ""
 
+msgctxt "#30016"
+msgid "Playback Control"
+msgstr ""
+
 # setting items
 msgctxt "#30040"
 msgid "Enable"
@@ -78,6 +82,34 @@ msgstr ""
 
 msgctxt "#30046"
 msgid "Select from Favourites"
+msgstr ""
+
+msgctxt "#30047"
+msgid "Random"
+msgstr ""
+
+msgctxt "#30048"
+msgid "Repeat"
+msgstr ""
+
+msgctxt "#30049"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30050"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30051"
+msgid "On"
+msgstr ""
+
+msgctxt "#30052"
+msgid "One"
+msgstr ""
+
+msgctxt "#30053"
+msgid "All"
 msgstr ""
 
 # ADDON STRINGS

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -23,5 +23,8 @@
 		<setting label="30014" type="lsep"/>
 		<setting id="volume-partymode" type="bool" label="30044" default="false"/>
 		<setting id="volume-level-partymode" subsetting="true" type="slider" label="30045" default="100" range="0,100" option="int" enable="eq(-1,true)"/>
+		<setting label="30016" type="lsep"/>
+		<setting id="playback-random" type="enum" label="30047" lvalues="30049|30050|30051"/>
+		<setting id="playback-repeat" type="enum" label="30048" lvalues="30049|30050|30052|30053"/>
 	</category>
 </settings>


### PR DESCRIPTION
Requested by forum users Roel23, jackbaurctu, and Debotchka:
https://forum.kodi.tv/showthread.php?tid=203290&pid=2452085#pid2452085
https://forum.kodi.tv/showthread.php?tid=203290&pid=2617192#pid2617192
https://forum.kodi.tv/showthread.php?tid=203290&pid=2625991#pid2625991

I took the liberty of extending their suggestions to include all available random options:
- Random Default (same as plugin's previous behavior, and does not execute a command at all)
- Random Off
- Random On

As well as all available repeat options:
- Repeat Default (same as plugin's previous behavior, and does not execute a command at all)
- Repeat Off
- Repeat One
- Repeat All