### PR TITLE
Set new values default

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -25,7 +25,7 @@
 		<setting id="volume-partymode" type="bool" label="30044" default="false"/>
 		<setting id="volume-level-partymode" subsetting="true" type="slider" label="30045" default="100" range="0,100" option="int" enable="eq(-1,true)"/>
 		<setting label="30016" type="lsep"/>
-		<setting id="playback-random" type="enum" label="30047" lvalues="30049|30050|30051"/>
-		<setting id="playback-repeat" type="enum" label="30048" lvalues="30049|30050|30052|30053"/>
+		<setting id="playback-random" type="enum" label="30047" lvalues="30049|30050|30051" default="0"/>
+		<setting id="playback-repeat" type="enum" label="30048" lvalues="30049|30050|30052|30053" default="0"/>
 	</category>
 </settings>


### PR DESCRIPTION
The new options introduced in 0.9.0b have no defaults, so an update from previous 0.8.8b will fail.
This fixes #6 